### PR TITLE
fix(rest): add tag to utoipa paths

### DIFF
--- a/server/src/rest_api.rs
+++ b/server/src/rest_api.rs
@@ -34,6 +34,7 @@ macro_rules! req_debug {
 #[utoipa::path(
     post,
     path = "/telemetry/adsb",
+    tag = "svc-telemetry",
     request_body = AdsbPacket,
     responses(
         (status = 200, description = "Telemetry received."),


### PR DESCRIPTION
Adds proper tags to rest API paths so the openapi files can be combined for publishing.